### PR TITLE
Remove base application_record from engine

### DIFF
--- a/app/models/defra_ruby_features/application_record.rb
+++ b/app/models/defra_ruby_features/application_record.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-module DefraRubyFeatures
-  class ApplicationRecord < ActiveRecord::Base
-    self.abstract_class = true
-  end
-end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1118

When running locally the new feature toggle functionality works great. However, when we tried running a version of [waste-carriers-back-office](https://github.com/DEFRA/waste-carriers-back-office) with the gem included in our AWS environments we got the following error

```
	28: from config.ru:5:in `block in <main>'
	27: from /srv/ruby/waste-carriers-back-office/releases/20200703112139/config/environment.rb:7:in `<top (required)>'
	26: from /srv/ruby/waste-carriers-back-office/shared/bundle/ruby/2.7.0/gems/railties-6.0.3.2/lib/rails/application.rb:363:in `initialize!'
	25: from /srv/ruby/waste-carriers-back-office/shared/bundle/ruby/2.7.0/gems/railties-6.0.3.2/lib/rails/initializable.rb:60:in `run_initializers'
	24: from /home/ubuntu/.rbenv/versions/2.7.1/lib/ruby/2.7.0/tsort.rb:205:in `tsort_each'
	23: from /home/ubuntu/.rbenv/versions/2.7.1/lib/ruby/2.7.0/tsort.rb:226:in `tsort_each'
	22: from /home/ubuntu/.rbenv/versions/2.7.1/lib/ruby/2.7.0/tsort.rb:347:in `each_strongly_connected_component'
	21: from /home/ubuntu/.rbenv/versions/2.7.1/lib/ruby/2.7.0/tsort.rb:347:in `call'
	20: from /home/ubuntu/.rbenv/versions/2.7.1/lib/ruby/2.7.0/tsort.rb:347:in `each'
	19: from /home/ubuntu/.rbenv/versions/2.7.1/lib/ruby/2.7.0/tsort.rb:349:in `block in each_strongly_connected_component'
	18: from /home/ubuntu/.rbenv/versions/2.7.1/lib/ruby/2.7.0/tsort.rb:431:in `each_strongly_connected_component_from'
	17: from /home/ubuntu/.rbenv/versions/2.7.1/lib/ruby/2.7.0/tsort.rb:350:in `block (2 levels) in each_strongly_connected_component'
	16: from /home/ubuntu/.rbenv/versions/2.7.1/lib/ruby/2.7.0/tsort.rb:228:in `block in tsort_each'
	15: from /srv/ruby/waste-carriers-back-office/shared/bundle/ruby/2.7.0/gems/railties-6.0.3.2/lib/rails/initializable.rb:61:in `block in run_initializers'
	14: from /srv/ruby/waste-carriers-back-office/shared/bundle/ruby/2.7.0/gems/railties-6.0.3.2/lib/rails/initializable.rb:32:in `run'
	13: from /srv/ruby/waste-carriers-back-office/shared/bundle/ruby/2.7.0/gems/railties-6.0.3.2/lib/rails/initializable.rb:32:in `instance_exec'
	12: from /srv/ruby/waste-carriers-back-office/shared/bundle/ruby/2.7.0/gems/railties-6.0.3.2/lib/rails/application/finisher.rb:123:in `block in <module:Finisher>'
	11: from /srv/ruby/waste-carriers-back-office/shared/bundle/ruby/2.7.0/gems/railties-6.0.3.2/lib/rails/application/finisher.rb:123:in `each'
	10: from /srv/ruby/waste-carriers-back-office/shared/bundle/ruby/2.7.0/gems/railties-6.0.3.2/lib/rails/engine.rb:356:in `eager_load!'
	 9: from /srv/ruby/waste-carriers-back-office/shared/bundle/ruby/2.7.0/gems/railties-6.0.3.2/lib/rails/engine.rb:477:in `eager_load!'
	 8: from /srv/ruby/waste-carriers-back-office/shared/bundle/ruby/2.7.0/gems/railties-6.0.3.2/lib/rails/engine.rb:477:in `each'
	 7: from /srv/ruby/waste-carriers-back-office/shared/bundle/ruby/2.7.0/gems/railties-6.0.3.2/lib/rails/engine.rb:480:in `block in eager_load!'
	 6: from /srv/ruby/waste-carriers-back-office/shared/bundle/ruby/2.7.0/gems/railties-6.0.3.2/lib/rails/engine.rb:480:in `each'
	 5: from /srv/ruby/waste-carriers-back-office/shared/bundle/ruby/2.7.0/gems/railties-6.0.3.2/lib/rails/engine.rb:481:in `block (2 levels) in eager_load!'
	 4: from /srv/ruby/waste-carriers-back-office/shared/bundle/ruby/2.7.0/gems/activesupport-6.0.3.2/lib/active_support/dependencies/interlock.rb:13:in `loading'
	 3: from /srv/ruby/waste-carriers-back-office/shared/bundle/ruby/2.7.0/gems/activesupport-6.0.3.2/lib/active_support/concurrency/share_lock.rb:151:in `exclusive'
	 2: from /srv/ruby/waste-carriers-back-office/shared/bundle/ruby/2.7.0/gems/activesupport-6.0.3.2/lib/active_support/dependencies/interlock.rb:14:in `block in loading'
	 1: from /srv/ruby/waste-carriers-back-office/shared/bundle/ruby/2.7.0/bundler/gems/defra-ruby-features-4d94a5c25906/app/models/defra_ruby_features/application_record.rb:3:in `<top (required)>'
/srv/ruby/waste-carriers-back-office/shared/bundle/ruby/2.7.0/bundler/gems/defra-ruby-features-4d94a5c25906/app/models/defra_ruby_features/application_record.rb:4:in `<module:DefraRubyFeatures>': uninitialized constant DefraRubyFeatures::ActiveRecord (NameError)
```

The error points to the `application_record.rb` file and some [Googling](https://stackoverflow.com/a/15731130/6117745) suggests it could be because ActiveRecord is trying to make a connection but can't. As we don't actually use `application_record.rb` in the solution (persistance to the database has to be handled by the host app) our first attempt at resolving this is to simply remove it from the gem.