### PR TITLE
Fix changelog implementation

### DIFF
--- a/lib/tasks/changelog.rake
+++ b/lib/tasks/changelog.rake
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require "github_changelog_generator/task"
+
+GitHubChangelogGenerator::RakeTask.new :changelog do |config|
+  config.user = "DEFRA"
+  config.project = "defra-ruby-features"
+end


### PR DESCRIPTION
We use the [github-changelog-generator](https://github.com/github-changelog-generator/github-changelog-generator) to automatically generate our CHANGELOGS.

Spotted the gem had been added to this project but that the rake task had not been setup. This fixes the issue and gets the generator working.