### PR TITLE
Update reference to CanCanCan in gemspec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    defra_ruby_features (0.1.0)
+    defra_ruby_features (0.1.1)
       cancancan (>= 1.10)
       devise (>= 4.4.3)
       rails (~> 6.0.3, >= 6.0.3.2)
@@ -67,10 +67,10 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.1)
-    bcrypt (3.1.13)
+    bcrypt (3.1.15)
     builder (3.2.4)
     byebug (11.1.3)
-    cancancan (1.17.0)
+    cancancan (3.1.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.6)
     crass (1.0.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     defra_ruby_features (0.1.0)
-      cancancan (~> 1.10)
+      cancancan (>= 1.10)
       devise (>= 4.4.3)
       rails (~> 6.0.3, >= 6.0.3.2)
 

--- a/defra_ruby_features.gemspec
+++ b/defra_ruby_features.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
 
   # Use CanCanCan for user roles and permissions
   # Version 2.0 doesn't support Mongoid, so we're locked to an earlier one
-  s.add_dependency  "cancancan", "~> 1.10"
+  s.add_dependency  "cancancan", ">= 1.10"
 
   # Use Devise for user authentication
   s.add_dependency  "devise", ">= 4.4.3"

--- a/defra_ruby_features.gemspec
+++ b/defra_ruby_features.gemspec
@@ -22,7 +22,10 @@ Gem::Specification.new do |s|
   s.add_dependency "rails", "~> 6.0.3", ">= 6.0.3.2"
 
   # Use CanCanCan for user roles and permissions
-  # Version 2.0 doesn't support Mongoid, so we're locked to an earlier one
+  # waste-carriers (WCR) has CanCanCan locked to v1.10. It uses MongoDb and
+  # Mongoid and CanCanCan dropped support for Mongoid in v2.
+  # WEX uses PostgreSQL and uses CanCanCan v2.3. So we know our minimum but we
+  # can't lock to a specific because we have to deal with both services.
   s.add_dependency  "cancancan", ">= 1.10"
 
   # Use Devise for user authentication

--- a/lib/defra_ruby_features/version.rb
+++ b/lib/defra_ruby_features/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DefraRubyFeatures
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1139

We'd like the ability to switch off features in our services from the UI rather than having to go through an RfC process. Because we want to do this in multiple services we built this engine.

This change is dealing with an issue that has arisen between WCR and WEX. WCR uses MongoDb and hence the [Mongoid framework](https://github.com/mongodb/mongoid). WEX uses PostgreSql. Both use [cancancan](https://github.com/CanCanCommunity/cancancan) for authorzation.

However, support for Mongoid in CanCanCan was dropped from v2 onwards so WCR has CanCanCan locked to v1.10. WEX though expects v2.3 or greater. Because of this we are changing how CanCanCan is referenced in the spec. Rather than saying v1.10.x is expected we now just say v1.10 is the minimum.